### PR TITLE
Fix wrong runtime in LambdaAPI x86

### DIFF
--- a/Examples/ItemAPI/serverless-x86_64.yml
+++ b/Examples/ItemAPI/serverless-x86_64.yml
@@ -6,7 +6,7 @@ provider:
   name: aws
   region: us-east-1
   disableRollback: false
-  runtime: provided
+  runtime: provided.al2
   httpApi:
     payload: '2.0'
     cors: false

--- a/Sources/BreezeCommand/GenerateLambdaAPI/GenerateLambdaAPI.swift
+++ b/Sources/BreezeCommand/GenerateLambdaAPI/GenerateLambdaAPI.swift
@@ -67,7 +67,7 @@ struct GenerateLambdaAPI: ParsableCommand {
             region: Region(rawValue: config.awsRegion) ?? .us_east_1,
             authorizer: config.authorizer,
             cors: config.cors,
-            runtime: .provided,
+            runtime: .providedAl2,
             architecture: .x86_64,
             memorySize: 256,
             executable: params.targetName,

--- a/Tests/BreezeCommandTests/GenerateLambdaAPITests.swift
+++ b/Tests/BreezeCommandTests/GenerateLambdaAPITests.swift
@@ -39,7 +39,7 @@ class GenerateLambdaAPITests: XCTestCase {
         try assertServerlessConfig(serverlessConfig: serverlessConfig, runtime: .providedAl2, architecture: .arm64)
         
         let serverlessConfigX86 = try loadServerlessConfig(targetPath: targetPath, fileName: "serverless-x86_64")
-        try assertServerlessConfig(serverlessConfig: serverlessConfigX86, runtime: .provided, architecture: .x86_64)
+        try assertServerlessConfig(serverlessConfig: serverlessConfigX86, runtime: .providedAl2, architecture: .x86_64)
     }
     
     func test_generateLambdaAPI_run_whenParametersAreSet_andSignInWithAppleConfig_thenSuccess() async throws {
@@ -51,7 +51,7 @@ class GenerateLambdaAPITests: XCTestCase {
         try assertServerlessConfigWithJWT(serverlessConfig: serverlessConfig, runtime: .providedAl2, architecture: .arm64)
         
         let serverlessConfigX86 = try loadServerlessConfig(targetPath: targetPath, fileName: "serverless-x86_64")
-        try assertServerlessConfigWithJWT(serverlessConfig: serverlessConfigX86, runtime: .provided, architecture: .x86_64)
+        try assertServerlessConfigWithJWT(serverlessConfig: serverlessConfigX86, runtime: .providedAl2, architecture: .x86_64)
     }
     
     func test_generateLambdaAPI_run_whenParametersAreSetAndForceOverrideIsFalse_thenErrorOnSecondRun() async throws {


### PR DESCRIPTION
Ensure that the `runtime` property is set to `provided.al2`